### PR TITLE
Performance Optimizations for sparse long and wide random matrices

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,15 @@ ISSUES:
   When there are only few random effects an alternative computation would 
   be much better.
 
+0.2-8
+* Pass optimizer arguments to lme4 / lmer
+
+* Optimize Fabian Scheipl's replacement operations with a sparse non-zero indexing approach
+
+* Disable condVar when calling ranef
+
+* Add the option to use scikit-sparse to compute the Cholesky Decomposition of the data covariance matrix.
+
 0.2-7
 
 * Matrix::chol no longer (since 1.6-3) returns the pivot sequence, rendering 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Description: Estimate generalized additive mixed models via a version of
 Depends: R (>= 4.4.0), methods, Matrix (>= 1.7-0), lme4 (>= 1.0), mgcv
         (>= 1.9-2)
 License: GPL (>= 2)
+Suggests: reticulate
 NeedsCompilation: no
 Packaged: 2025-04-22 09:32:25 UTC; sw283
 Author: Simon Wood [aut, cre],

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gamm4
-Version: 0.2-7
+Version: 0.2-8
 Authors@R: c(person(given = "Simon",
                       family = "Wood",
                       role = c("aut","cre"),

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -349,8 +349,28 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
          B[ind,ind] <- t(D*t(G$smooth[[i]]$trans.U))
       }
       ## and finally transform G$Xf into fitting parameterization...
-      Xfp[,ind] <- G$Xf[,ind,drop=FALSE]%*%B[ind,ind,drop=FALSE]
+      rep <- G$Xf[,ind,drop=FALSE]%*%B[ind,ind,drop=FALSE]
 
+      # sparse summaries
+      sum_rep <- summary(rep)
+      sum_Xfp <- summary(Xfp)
+
+      # replace column indexes in rep
+      sum_rep$j <- ind[sum_rep$j]
+
+      # remove columns from orig
+      sum_Xfp <- subset(sum_Xfp, !(j %in% ind))
+
+      # merge
+      sum_comb <- rbind(sum_Xfp, sum_rep)
+
+      # recreate updated sparse matrix
+      Xfp <- sparseMatrix(
+        i = sum_comb$i,
+        j = sum_comb$j,
+        x = sum_comb$x,
+        dims = dim(Xfp)
+      )
     }
  
     object$coefficients <- p

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -244,14 +244,13 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
     ## Create the deviance function to be optimized:
     devfun <- do.call(mkLmerDevfun, b)
     ## Optimize the deviance function:
-    opt <- optimizeLmer(devfun,start=start,verbose=verbose,control=control$optCtrl) ## previously bobyqa optimizer set, but now default
-    ## Package up the results:
+    opt <- optimizeLmer(devfun,start=start,verbose=verbose,control=control$optCtrl,optimizer=control$optimizer)
     ret$mer <- mkMerMod(environment(devfun), opt, b$reTrms, fr = b$fr)
   } else { ## generalized case...
     ## Create the deviance function for optimizing over theta:
     devfun <- do.call(mkGlmerDevfun, b)
     ## Optimize over theta using a rough approximation (i.e. nAGQ = 0):
-    opt <- optimizeGlmer(devfun,start=start,verbose=verbose,control=control$optCtrl)
+    opt <- optimizeGlmer(devfun,start=start,verbose=verbose,control=control$optCtrl,optimizer=control$optimizer)
     ## Update the deviance function for optimizing over theta and beta:
     devfun <- updateGlmerDevfun(devfun, b$reTrms)
     ## Optimize over theta and beta:

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -286,8 +286,8 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
     Xfp <- G$Xf
     ## Transform  parameters back to the original space....
     bf <- as.numeric(lme4::fixef(ret$mer)) ## the fixed effects
-    br <- lme4::ranef(ret$mer) ## a named list
-    if (G$nsdf) p <- bf[1:G$nsdf] else p <- array(0,0) ## fixed parametric component
+    br <- lme4::ranef(ret$mer, condVar=FALSE) ## a named list
+    if (G$nsdf) p <- bf[1:G$nsdf] else p <- array(0,0) ## fixed parametric componet
     if (G$m>0) for (i in 1:G$m) {
       fx <- G$smooth[[i]]$fixed 
       first <- G$smooth[[i]]$first.f.para; last <- G$smooth[[i]]$last.f.para
@@ -470,11 +470,6 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
     ret
 
 } ## end of gamm4
-
-
-
-
-
 
 
 print.gamm4.version <- function() {

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -117,7 +117,7 @@ gamm4.setup<-function(formula,pterms,
 
 gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL,
       subset=NULL,na.action,knots=NULL,drop.unused.levels=TRUE,REML=TRUE,
-      control=NULL,start=NULL,verbose=0L,...) {
+      control=NULL,start=NULL,verbose=0L,nAGQ=1L,...) {
 # Routine to fit a GAMM to some data. Fixed and smooth terms are defined in the formula, but the wiggly 
 # parts of the smooth terms are treated as random effects. The onesided formula random defines additional 
 # random terms. 
@@ -135,7 +135,7 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
  
   mf$formula <- gp$fake.formula
   mf$REML <- mf$verbose <- mf$control <- mf$start <- mf$family <- mf$scale <-
-             mf$knots <- mf$random <- mf$... <-NULL ## mf$weights?
+             mf$knots <- mf$random <- mf$nAGQ <- mf$... <-NULL ## mf$weights?
   mf$drop.unused.levels <- drop.unused.levels
   mf[[1]] <- as.name("model.frame")
   pmf <- mf
@@ -282,17 +282,17 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
     ## Create the deviance function to be optimized:
     devfun <- do.call(mkLmerDevfun, b)
     ## Optimize the deviance function:
-    opt <- optimizeLmer(devfun,start=start,verbose=verbose,control=control$optCtrl,optimizer=control$optimizer)
+    opt <- optimizeLmer(devfun,start=start,verbose=verbose,control=control$optCtrl,optimizer=control$optimizer[[1]],calc.derivs=control$calc.derivs,boundary.tol=control$boundary.tol)
     ret$mer <- mkMerMod(environment(devfun), opt, b$reTrms, fr = b$fr)
   } else { ## generalized case...
     ## Create the deviance function for optimizing over theta:
     devfun <- do.call(mkGlmerDevfun, b)
     ## Optimize over theta using a rough approximation (i.e. nAGQ = 0):
-    opt <- optimizeGlmer(devfun,start=start,verbose=verbose,control=control$optCtrl,optimizer=control$optimizer)
+    opt <- optimizeGlmer(devfun,start=start,verbose=verbose,control=control$optCtrl,optimizer=control$optimizer[[1]],calc.derivs=control$calc.derivs,boundary.tol=control$boundary.tol,nAGQ=0)
     ## Update the deviance function for optimizing over theta and beta:
     devfun <- updateGlmerDevfun(devfun, b$reTrms)
     ## Optimize over theta and beta:
-    opt <- optimizeGlmer(devfun, stage=2,start=start,verbose=verbose,control=control$optCtrl)
+    opt <- optimizeGlmer(devfun, stage=2,start=start,verbose=verbose,control=control$optCtrl,optimizer=control$optimizer[[1]],calc.derivs=control$calc.derivs,boundary.tol=control$boundary.tol,nAGQ=nAGQ)
     ## Package up the results:
     ret$mer <- mkMerMod(environment(devfun), opt, b$reTrms, fr = b$fr)
   }

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -237,14 +237,18 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
       indices <- which(t(G$random[[i]]) != 0, arr.ind = TRUE)
       values <- t(G$random[[i]])[indices]
       
-      # Step 2: Create dense summary DataFrame
+      # Step 2: Create dense summary DataFrame for the smooth submatrix
       dense_summary <- data.frame(i = indices[, 1], j = indices[, 2], x = values)
       
       # Step 3: Adjust row indices according to b$reTrms$Gp[k]
       dense_summary$i <- dense_summary$i + b$reTrms$Gp[k]
+      #ii <- (b$reTrms$Gp[k]+1):b$reTrms$Gp[k+1]
+      #message("Debug: ii ", ii)
+      #message("Debug: summary ", dense_summary$i)
+
       
-      # Step 4: Remove rows from sparse_summary that have the same (i, j) as in dense_summary
-      filtered_sparse_summary <- sparse_summary[!paste(sparse_summary$i, sparse_summary$j) %in% paste(dense_summary$i, dense_summary$j), ]
+      # Step 4: Remove rows from sparse_summary that have the same i as in dense_summary
+      filtered_sparse_summary <- sparse_summary[!(sparse_summary$i %in% dense_summary$i), ]
       
       # Step 5: Combine the filtered sparse summary with the dense summary
       combined_summary <- rbind(filtered_sparse_summary, dense_summary)
@@ -349,28 +353,29 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
          B[ind,ind] <- t(D*t(G$smooth[[i]]$trans.U))
       }
       ## and finally transform G$Xf into fitting parameterization...
-      rep <- G$Xf[,ind,drop=FALSE]%*%B[ind,ind,drop=FALSE]
+      Xfp[,ind] <- as.matrix(G$Xf[,ind,drop=FALSE]%*%B[ind,ind,drop=FALSE])
+      #rep <- G$Xf[,ind,drop=FALSE]%*%B[ind,ind,drop=FALSE]
 
       # sparse summaries
-      sum_rep <- summary(rep)
-      sum_Xfp <- summary(Xfp)
+      #sum_rep <- summary(rep)
+      #sum_Xfp <- summary(Xfp)
 
       # replace column indexes in rep
-      sum_rep$j <- ind[sum_rep$j]
+      #sum_rep$j <- ind[sum_rep$j]
 
       # remove columns from orig
-      sum_Xfp <- subset(sum_Xfp, !(j %in% ind))
+      #sum_Xfp <- subset(sum_Xfp, !(j %in% ind))
 
       # merge
-      sum_comb <- rbind(sum_Xfp, sum_rep)
+      #sum_comb <- rbind(sum_Xfp, sum_rep)
 
       # recreate updated sparse matrix
-      Xfp <- sparseMatrix(
-        i = sum_comb$i,
-        j = sum_comb$j,
-        x = sum_comb$x,
-        dims = dim(Xfp)
-      )
+      #Xfp <- sparseMatrix(
+      #  i = sum_comb$i,
+      #  j = sum_comb$j,
+      #  x = sum_comb$x,
+      #  dims = dim(Xfp)
+      #)
     }
  
     object$coefficients <- p

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -117,7 +117,7 @@ gamm4.setup<-function(formula,pterms,
 
 gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL,
       subset=NULL,na.action,knots=NULL,drop.unused.levels=TRUE,REML=TRUE,
-      control=NULL,start=NULL,verbose=0L,nAGQ=1L,...) {
+      control=NULL,start=NULL,verbose=0L,nAGQ=1L,python_cholmod=FALSE,...) {
 # Routine to fit a GAMM to some data. Fixed and smooth terms are defined in the formula, but the wiggly 
 # parts of the smooth terms are treated as random effects. The onesided formula random defines additional 
 # random terms. 
@@ -135,7 +135,7 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
  
   mf$formula <- gp$fake.formula
   mf$REML <- mf$verbose <- mf$control <- mf$start <- mf$family <- mf$scale <-
-             mf$knots <- mf$random <- mf$nAGQ <- mf$... <-NULL ## mf$weights?
+             mf$knots <- mf$random <- mf$nAGQ <- mf$python_cholmod <- mf$... <-NULL ## mf$weights?
   mf$drop.unused.levels <- drop.unused.levels
   mf[[1]] <- as.name("model.frame")
   pmf <- mf
@@ -427,18 +427,34 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
 
     ## NOTE: Cholesky probably better in the following - then pivoting 
     ##       automatic when solving....
-    #R <- Matrix::chol(V,pivot=TRUE);piv <- attr(R,"pivot") ## from >1.6-2 pivot not returned!?
-    R <- mgcv::mchol(V);piv <- attr(R,"pivot") 
+
+    if (python_cholmod) {
+      library(reticulate)
+      py_require(packages="scikit-sparse>=0.4.16")
+      cholmod <- import("sksparse.cholmod")
+      R <- cholmod$cholesky(V)
+    } else {
+      R <- mgcv::mchol(V);piv <- attr(R,"pivot")
+    }
+
     G$Xf <- as(G$Xf,"dgCMatrix")
     Xfp <- as(Xfp,"dgCMatrix")
     
-    if (is.null(piv)) {
-      WX <- as(solve(t(R),Xfp),"matrix")    ## V^{-.5}Xp -- fit parameterization
-      XVX <- as(solve(t(R),G$Xf),"matrix")  ## same in original parameterization 
+    if (python_cholmod) {
+      WX <- as.matrix(R$solve_Lt(Xfp,use_LDLt_decomposition=FALSE))
+      XVX <- as.matrix(R$solve_Lt(G$Xf,use_LDLt_decomposition=FALSE))
     } else {
+
+      if (is.null(piv)) {
+      WX <- as(solve(t(R),Xfp),"matrix")    ## V^{-.5}Xp -- fit parameterization
+      XVX <- as(solve(t(R),G$Xf),"matrix")  ## same in original parameterization
+
+      } else {
       WX <- as(solve(t(R),Xfp[piv,]),"matrix")    ## V^{-.5}Xp -- fit parameterization
       XVX <- as(solve(t(R),G$Xf[piv,]),"matrix")  ## same in original parameterization
+      }
     }
+
     qrz <- qr(XVX,LAPACK=TRUE)
     object$R <- qr.R(qrz);object$R[,qrz$pivot] <- object$R
 

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -221,17 +221,55 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
   b <- if (linear) lFormula(lme4.formula,data=mf,weights=G$w,REML=REML,control=control,...) else 
                    glFormula(lme4.formula,data=mf,family=family,weights=G$w,control=control,...)
 
- 
-  if (n.sr) { ## Fabian Scheipl's trick of overwriting dummy slots revised for new structure
-     tn <- names(b$reTrms$cnms) ## names associated with columns of Z (same order as Gp)
-     ind <- 1:length(tn)
-     sn <- names(G$random) ## names of smooth random components
-     for (i in 1:n.sr) { ## loop through random effect smooths
-       k <- ind[sn[i]==tn] ## which term should contain G$random[[i]] 
-       ii <- (b$reTrms$Gp[k]+1):b$reTrms$Gp[k+1]
-       b$reTrms$Zt[ii,] <- as(t(G$random[[i]]),"dgCMatrix")
-       b$reTrms$cnms[[k]] <- attr(G$random[[i]],"s.label") 
-     }
+    ## loop through random effect smooths and ingest them into Z
+  if (n.sr) {
+    tn <- names(b$reTrms$cnms) ## names associated with columns of Z (same order as Gp)
+    ind <- 1:length(tn)
+    sn <- names(G$random)
+
+    sparse_summary <- as.data.frame(summary(b$reTrms$Zt))
+    sparse_dims <- dim(b$reTrms$Zt)
+
+    for (i in 1:n.sr) {
+      k <- ind[sn[i]==tn] ## which term (variable) name represents random smooth i
+
+      # Step 1: Extract indices and values from the transposed matrix
+      indices <- which(t(G$random[[i]]) != 0, arr.ind = TRUE)
+      values <- t(G$random[[i]])[indices]
+      
+      # Step 2: Create dense summary DataFrame
+      dense_summary <- data.frame(i = indices[, 1], j = indices[, 2], x = values)
+      
+      # Step 3: Adjust row indices according to b$reTrms$Gp[k]
+      dense_summary$i <- dense_summary$i + b$reTrms$Gp[k]
+      
+      # Step 4: Remove rows from sparse_summary that have the same (i, j) as in dense_summary
+      filtered_sparse_summary <- sparse_summary[!paste(sparse_summary$i, sparse_summary$j) %in% paste(dense_summary$i, dense_summary$j), ]
+      
+      # Step 5: Combine the filtered sparse summary with the dense summary
+      combined_summary <- rbind(filtered_sparse_summary, dense_summary)
+
+      # Step 6: Update sparse_summary
+      sparse_summary <- combined_summary
+      
+      # Step 7: Update labels
+      b$reTrms$cnms[[k]] <- attr(G$random[[i]],"s.label") 
+      }
+
+    # Create the new sparse matrix
+    new_sparse_mat <- sparseMatrix(
+          i = sparse_summary$i,
+          j = sparse_summary$j,
+          x = sparse_summary$x,
+          dims = c(sparse_dims[1], sparse_dims[2])
+        )
+        
+    # Assign row and column names from the original matrix
+    rownames(new_sparse_mat) <- rownames(b$reTrms$Zt)
+    colnames(new_sparse_mat) <- colnames(b$reTrms$Zt)
+
+    # Replace old Zt with the updated one
+    b$reTrms$Zt <- new_sparse_mat
   }
 
   ## now do the actual fitting...

--- a/R/gamm4.r
+++ b/R/gamm4.r
@@ -478,12 +478,20 @@ gamm4 <- function(formula,random=NULL,family=gaussian(),data=list(),weights=NULL
 
 
 
-print.gamm4.version <- function()
-{ library(help=gamm4)$info[[1]] -> version
-  version <- version[pmatch("Version",version)]
-  um <- strsplit(version," ")[[1]]
-  version <- um[nchar(um)>0][2]
-  hello <- paste("This is gamm4 ",version,"\n",sep="")
+print.gamm4.version <- function() {
+  if (requireNamespace("gamm4", quietly = TRUE)) {
+    version_info <- packageDescription("gamm4")$Version
+  } else {
+    # fallback: try to read DESCRIPTION manually (for devtools::load_all)
+    desc_path <- file.path(dirname(sys.frame(1)$ofile), "..", "DESCRIPTION")
+    if (file.exists(desc_path)) {
+      dcf <- read.dcf(desc_path)
+      version_info <- dcf[1, "Version"]
+    } else {
+      version_info <- "unknown"
+    }
+  }
+  hello <- paste("This is gamm4 ", version_info, "\n", sep = "")
   packageStartupMessage(hello)
 }
 
@@ -493,4 +501,3 @@ print.gamm4.version <- function()
 }
 
 .onUnload <- function(libpath) {}
-

--- a/man/gamm4.Rd
+++ b/man/gamm4.Rd
@@ -33,7 +33,7 @@ To use this function effectively it helps to be quite familiar with the use of
 \usage{
 gamm4(formula,random=NULL,family=gaussian(),data=list(),weights=NULL,
       subset=NULL,na.action,knots=NULL,drop.unused.levels=TRUE,
-      REML=TRUE,control=NULL,start=NULL,verbose=0L,...)
+      REML=TRUE,control=NULL,start=NULL,verbose=0L,python_choldmod=FALSE,...)
 }
 
 \arguments{ 
@@ -77,6 +77,8 @@ involving factor variables you might want to turn this off. Only do so if you kn
 \item{start}{starting value list as used by \code{\link[lme4]{lmer}} or \code{\link[lme4]{glmer}}.}
 
 \item{verbose}{passed on to fitting \code{lme4} fitting routines.}
+
+\item{python_cholmod}{Use \code{scikit-sparse} over \code{reticulate} to compute the Cholesky Decomposition of the data covariance matrix. This may lead to performance benefits for very large datasets.}
 
 \item{...}{further arguments for passing on to model setup routines.} 
 }


### PR DESCRIPTION
# Performance Evaluation

## Compute Node
```
## System Information

### OS
Description:    Ubuntu 22.04.5 LTS

### Kernel
6.8.0-45-generic

### CPU
Architecture:                         x86_64
CPU(s):                               32
On-line CPU(s) list:                  0-31
Model name:                           AMD Ryzen Threadripper PRO 5955WX 16-Cores
NUMA node0 CPU(s):                    0-31

### Memory
               total
Mem:           503Gi

### R
R version 4.5.1 (2025-06-13) -- "Great Square Root"
Copyright (C) 2025 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu
```

## Comparison
The aim of this performance evaluation is to compare the two following gamm4 versions:

- `current` (2.6 / 2.7): current vanilla gamm4 - Optimizer is always nloptwrap since the optimizer argument is not propagated properly.
- `mod` (2.8 ?): modified version of gamm4 with bug fixed, scikit-sparse support for data covariance matrix Cholesky decomposition and performance-optimized version of Fabian Scheipl's trick

## Heat Stress Dataset

More info about the data: https://aschneuw.github.io/heatstress/materials/

```
model <- gamm4(
  formula= milk ~ 1 + s(thi_mean_t0_3d, by=parity, k=10) + s(days_in_milk_t, by=parity, k=15) + parity + year,
  random =~((1 | zip_month) + (1 | farmIdLocationSample) + (1 | animalId)),
  data = data,
  drop.unused.levels = TRUE,
  REML = TRUE,
  control = lmerControl(calc.derivs = FALSE, optCtrl = list(optimizer="nloptwrap", maxfun = 10000)),
  verbose = 10,
  python_cholmod = TRUE
)
```
 

|Version|Samples|Animals|Farms|ZIPxMonth|Optimizer|scikit-sparse|Execution Time [s]|
|-|-|-|-|-|-|-|-|
|2.7|500'000|23'675|4'241|16'056|nloptwrap|-|21'536|
|2.7|734’685|23'675|4'302|16'648|nloptwrap|-|crash|
|mod|500'000|23'675|4'241|16'056|nloptwrap|False|5'240|
|mod|500'000|23'675|4'241|16'056|nloptwrap|True|4'316|
|mod|734’685|23'675|4'302|16'648|nloptwrap|False|crash|
|mod|734’685|23'675|4'302|16'648|nloptwrap|True|6'089|
|mod|734’685|23'675|4'302|16'648|BOBYQA|True|6'067|


## Random Data Example from Documentation
Benchmarking a mixed model example from the documentation (with more samples and factor levels) with microbench.

### Current
```
gamm4_example <- function() {
    set.seed(0) 
    
    n = 20000
    m = 2000
    dat <- gamSim(1, n = n, scale = 2)  # simulate 4-term additive truth
    
    # Add 3,000-level random effect 'fac'
    dat$fac <- fac <- as.factor(sample(1:m, n, replace = TRUE))
    dat$y <- dat$y + model.matrix(~fac - 1) %*% rnorm(m) * 0.5
    
    # Fit gamm4 model
    br <- gamm4(y ~ s(x0) + x1 + s(x2), data = dat, random = ~(1 | fac))
    plot(br$gam, pages = 1)
    
    # Model summaries
    summary(br$gam)  # summary of gam
    summary(br$mer)  # underlying mixed model
}
```

```
Unit: seconds
            expr      min       lq     mean   median       uq     max neval
 gamm4_example() 17.02194 17.29564 18.51402 19.16437 19.44374 19.6596   100
```



### Mod

```
gamm4_example <- function() {
    set.seed(0) 
    
    n = 20000
    m = 2000
    dat <- gamSim(1, n = n, scale = 2)  # simulate 4-term additive truth
    
    # Add 3,000-level random effect 'fac'
    dat$fac <- fac <- as.factor(sample(1:m, n, replace = TRUE))
    dat$y <- dat$y + model.matrix(~fac - 1) %*% rnorm(m) * 0.5
    
    # Fit gamm4 model
    br <- gamm4(y ~ s(x0) + x1 + s(x2), data = dat, random = ~(1 | fac), python_cholmod=TRUE)
    plot(br$gam, pages = 1)
    
    # Model summaries
    summary(br$gam)  # summary of gam
    summary(br$mer)  # underlying mixed model
}
```

```
Unit: seconds
            expr      min      lq     mean   median       uq      max neval
 gamm4_example() 8.155614 8.32772 9.079993 9.511128 9.655152 9.924096   100
```